### PR TITLE
Add support for `filter` for `TabularDataSet`s

### DIFF
--- a/legend-engine-xt-relationalai-pure/pom.xml
+++ b/legend-engine-xt-relationalai-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.engine</groupId>
         <artifactId>legend-engine</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>3.17.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/ir/ir.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/ir/ir.pure
@@ -493,7 +493,7 @@ function meta::rel::compile::ir::intoPExpr(func: FunctionExpression[1], set: Rel
               let error = error(| 
                 format('Encountered unknown qualified property while translating: `%s`', $property.name)
               );
-              error($error, @PExpr);
+              error($error);
             });
           });
         });
@@ -698,7 +698,7 @@ function meta::rel::compile::ir::intoPExpr(func: FunctionExpression[1], set: Rel
                         )
                         ->andThem({names: String[*] | 
                           if ($names->size() != $group->size() + $aggregates->size(),
-                            | error('Number of specified columns does not match the arity of the `group by` expression.', @PExpr),
+                            | error('Number of specified columns does not match the arity of the `group by` expression.'),
                             {|
                               let namedAggregates = 
                                 $aggregates
@@ -924,11 +924,13 @@ function meta::rel::compile::ir::intoPExpr(func: FunctionExpression[1], set: Rel
         case($other == meta::pure::tds::join_TabularDataSet_1__TabularDataSet_1__JoinType_1__Function_1__TabularDataSet_1_, {| 
           meta::rel::compile::ir::tds::intoPExpr($func);
         }),
+        case($other == meta::pure::tds::filter_TabularDataSet_1__Function_1__TabularDataSet_1_, {|
+          meta::rel::compile::ir::tds::intoPExpr($func);
+        }),
         case($other == meta::rel::query::def_String_1__FunctionDefinition_1__Any_MANY_, {| 
           let query = $func.parametersValues->at(1)->intoScoped()->unwrap()->inspect();
 
           meta::rel::compile::ir::const(1)->ok();
-          //error('Not implemented', @PExpr);
         })
       ], {|
         let error = error(| 
@@ -938,7 +940,7 @@ function meta::rel::compile::ir::intoPExpr(func: FunctionExpression[1], set: Rel
               ->else(| '<<unknown>>')
               ->quote();
         );
-        error($error, @PExpr);
+        error($error);
       });
     }
   ]);
@@ -949,7 +951,7 @@ function meta::rel::compile::ir::intoPExpr(spec: InstanceValue[1], set: RelSetIm
     ->okOr(| 'Expected value within `InstanceValue`.')
     ->andThem({values: Any[*] | 
       if ($values->size() != 1,
-        | error(error(| 'Expected exactly one value in `InstanceValue`.'), @PExpr),
+        | error(error(| 'Expected exactly one value in `InstanceValue`.')),
         | $values->toOne()->ok()
       );
     })
@@ -983,7 +985,7 @@ function meta::rel::compile::ir::intoPExpr(value: Any[1], set: RelSetImplementat
             ->else(| '<<unknown>>')
             ->quote();
       );
-      error($error, @PExpr);
+      error($error);
     }
   ])
 }
@@ -1019,7 +1021,7 @@ function meta::rel::compile::ir::intoScoped(func: FunctionDefinition<Any>[1], pa
     ->okOr(|'Encountered empty function body while evaluating expression.')
     ->andThem({exprs: ValueSpecification[*] |
       if ($exprs->size() != 1,
-        | error(error(| 'More than one expression in function body not supported yet.'), @Scoped),
+        | error(error(| 'More than one expression in function body not supported yet.')),
         | $exprs->toOne()->ok()
       );
     })
@@ -1094,14 +1096,14 @@ function meta::rel::compile::ir::intoAggregates(spec: ValueSpecification[1], par
         let error = error(| 
           format('Encountered unexpected aggregation function during translation: `%s`', $fexpr.func->elementToPath())
         );
-        error($error, @Aggregate);
+        error($error);
       });
     },
     {value: InstanceValue[1] |
       $value.values
         ->map({v | 
           let casted = $v->tryCast(@ValueSpecification);
-          if ($casted->isOk(), | $casted.values->toOne()->intoAggregates($parent), | error($casted.errors, @Aggregate));
+          if ($casted->isOk(), | $casted.values->toOne()->intoAggregates($parent), | error($casted.errors));
         });
     }
   ]);
@@ -1275,7 +1277,7 @@ function meta::rel::compile::ir::getFunctionExpr(
             ->else(| '<<unknown>>')
             ->quote();
       );
-      error($error, @FunctionDefinition<{Expr[*]->Expr[1]}>);
+      error($error);
     });
   
   let type = $fn.genericType.rawType;

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/ir/tds.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/ir/tds.pure
@@ -10,6 +10,11 @@ Class meta::rel::compile::ir::tds::Join extends PExpr {
   right: PExpr[1];
 }
 
+Class meta::rel::compile::ir::tds::TDSFilter extends PExpr {
+  parent: PExpr[1];
+  predicate: Scoped[1];
+}
+
 function meta::rel::compile::ir::tds::join(
   left: PExpr[1], 
   right: PExpr[1], 
@@ -17,6 +22,10 @@ function meta::rel::compile::ir::tds::join(
   condition: Scoped[1]
 ): Join[1] {
   ^Join(type=$type, condition=$condition, left=$left, right=$right);
+}
+
+function meta::rel::compile::ir::tds::filter(parent: PExpr[1], predicate: Scoped[1]): TDSFilter[1] {
+  ^TDSFilter(parent=$parent, predicate=$predicate);
 }
 
 function meta::rel::compile::ir::tds::intoPExpr(func: FunctionExpression[1]): Result<PExpr|0..1>[1] {
@@ -43,6 +52,19 @@ function meta::rel::compile::ir::tds::intoPExpr(func: FunctionExpression[1]): Re
                 });
             });
         });
+    }),
+    case($func.func == meta::pure::tds::filter_TabularDataSet_1__Function_1__TabularDataSet_1_, {|
+      $func.parametersValues
+        ->at(0)
+        ->meta::rel::compile::ir::intoPExpr()
+        ->andThen({parent: PExpr[1] |
+          $func.parametersValues
+            ->at(1)
+            ->meta::rel::compile::ir::intoScoped()
+            ->then({predicate: Scoped[1] |
+              meta::rel::compile::ir::tds::filter($parent, $predicate);
+            });
+        });
     })
   ], {| 
     let error = error(| 
@@ -52,6 +74,6 @@ function meta::rel::compile::ir::tds::intoPExpr(func: FunctionExpression[1]): Re
           ->else(| '<<unknown>>')
           ->quote();
     );
-    error($error, @PExpr);
+    error($error);
   })
 }

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/translate/tds.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/translate/tds.pure
@@ -94,3 +94,53 @@ function meta::rel::compile::tds::compile(
         });
     });
 }
+
+function meta::rel::compile::tds::compile(
+  filter: TDSFilter[1],
+  callback: FunctionDefinition<{Any[1]->Result<Expr|0..1>[1]}>[1],
+  state: CompilationState[1]
+): Result<CompilationState|0..1>[1] {
+  $filter.parent
+    ->compile($callback, $state)
+    ->andThen({parentState: CompilationState[1] |
+      let parent = $parentState.current->toOne();
+      let vx = var('x');
+      
+      $filter.predicate
+        ->compile({a: Any[1] |
+          $a->tryCast(@ColumnAccess)
+            ->andThen({access: ColumnAccess[1] |
+              let var = $access
+                ->root()
+                ->cast(@VariablePlaceholder)
+                .identifier;
+
+              if ($var == $filter.predicate.variables, {|
+                $parent
+                  ->appl([label($access.column), $vx])
+                  ->ok();
+              }, | $callback->eval($a));
+            });
+        }, $parentState)
+        ->then({next: CompilationState[1] |
+          let table = $next.relFactory->next('tbl');
+          let predicate = $next.current->toOne();
+
+          let vc = var('c');
+
+          let head = rel($table);
+          let rule = 
+            $head
+              ->appl([$vc, $vx])
+              ->def([
+                $parent->appl([$vc, $vx]),
+                $predicate
+              ]);
+
+          ^$next(
+            current=$head,
+            program=$next.program->with($rule)
+          );
+        });
+    });
+}

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/translate/translate.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/compile/translate/translate.pure
@@ -56,7 +56,8 @@ function meta::rel::compile::compile(
     forAll: meta::rel::compile::ir::ForAll[1] | $forAll->compile($callback, $state),
     step: CompilationStep[1] | $step.logic->eval($callback, $state),
     ifThenElse: meta::rel::compile::ir::IfThenElse[1] | $ifThenElse->compile($callback, $state),
-    join: meta::rel::compile::ir::tds::Join[1] | $join->meta::rel::compile::tds::compile($callback, $state);
+    join: meta::rel::compile::ir::tds::Join[1] | $join->meta::rel::compile::tds::compile($callback, $state),
+    filter: meta::rel::compile::ir::tds::TDSFilter[1] | $filter->meta::rel::compile::tds::compile($callback, $state)
   ]);
 }
 

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/mapping/execution.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/mapping/execution.pure
@@ -65,7 +65,7 @@ function <<access.private>> meta::rel::mapping::execution(
     ->andThen({node: PExpr[1] | 
       //$debug->debug(| 'PURE Expression plan:');
       //$debug->debug(| $node->meta::rel::compile::ir::utils::display());
-      $node->compile({_a: Any[1] | error('Unexpected error during compilation.', @Expr); }, $state);
+      $node->compile({_a: Any[1] | error('Unexpected error during compilation.'); }, $state);
     })
     ->andThen({state: CompilationState[1] | 
       $debug->debug(| 'Column names:');

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/mapping/frontend/frontend.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/mapping/frontend/frontend.pure
@@ -53,7 +53,7 @@ function meta::rel::mapping::frontend::insert<T>(connection: RAIConnection[1], o
   $connection
     .element
     ->tryCast(@RAISchema)
-    ->else(| error('Property `element` is not an instance of `meta::rel::frontend::RAISchema`.', @RAIResult))
+    ->else(| error('Property `element` is not an instance of `meta::rel::frontend::RAISchema`.'))
     ->andThen(schema: RAISchema[1] | $connection->insert($schema, $objects));
 }
 

--- a/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/utils/result.pure
+++ b/legend-engine-xt-relationalai-pure/src/main/resources/core_relationalai/utils/result.pure
@@ -29,8 +29,8 @@ function meta::rel::utils::okm<T>(values: T[*]): Result<T|*>[1] {
   ^Result<T|*>(values=$values);
 }
 
-function meta::rel::utils::error<T>(errors: Any[*], object: T[1]): Result<T|0..1>[1] {
-  ^Result<T|0..1>(errors=$errors);
+function meta::rel::utils::error(errors: Any[*]): Result<Nil|0..1>[1] {
+  ^Result<Nil|0..1>(errors=$errors);
 }
 
 function meta::rel::utils::andThen<S,T|n>(result: Result<S|0..1>[1], fn: FunctionDefinition<{S[1]->Result<T|n>[1]}>[1]): Result<T|n>[1] {
@@ -127,7 +127,7 @@ function meta::rel::utils::collect<T>(results: Result<T|0..1>[*]): Result<T|*>[1
 function meta::rel::utils::expand<T>(result: Result<T|*>[1]): Result<T|0..1>[*] {
   if ($result.errors->isEmpty(),
     | $result.values->map(v | ok($v)),
-    | $result.errors->map(e | error($e, @T))
+    | $result.errors->map(e | error($e))
   );
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
         <module>legend-engine-xt-relationalStore-bigquery-grammar</module>
         <module>legend-engine-xt-relationalStore-bigquery-pure</module>
 
+        <module>legend-engine-xt-relationalai-pure</module>
+
         <module>legend-engine-xt-avro</module>
         <module>legend-engine-xt-avro-pure</module>
 
@@ -188,7 +190,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>3.6.2</legend.pure.version>
+        <legend.pure.version>3.7.1-SNAPSHOT</legend.pure.version>
         <legend.shared.version>0.22.0</legend.shared.version>
 
         <!-- SONAR -->
@@ -743,6 +745,11 @@
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>
                 <artifactId>legend-engine-xt-relationalStore-postgres-execution-tests</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.engine</groupId>
+                <artifactId>legend-engine-xt-relationalai-pure</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
Adds support for `filter` for `TabularDataSet`s. 

**TODOs:**
- [x] Implement IR
- [x] Implement translation code

N.B.: Tests will come in a separate PR once support for TDS are in a more stable state.